### PR TITLE
replace youtube-dl with yt-dlp

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -53,7 +53,7 @@ brew_install rust
 brew_install httpie
 brew_install mas
 brew_install wget
-brew_install youtube-dl
+brew_install yt-dlp
 
 # Install fancy shell stuff
 brew_install autojump
@@ -82,6 +82,7 @@ brew_install thefuck
 
 # Install developer tools
 brew_install docker
+brew_install ffmpeg  # Also useful for yt-dlp
 brew_install postgresql
 brew_install redis
 


### PR DESCRIPTION
- youtube-dl is deprecated

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace the deprecated youtube-dl with yt-dlp in the brew installation script and add ffmpeg installation to support yt-dlp functionality.

Build:
- Replace youtube-dl with yt-dlp in the brew installation script.
- Add ffmpeg installation in the brew script, which is useful for yt-dlp.

<!-- Generated by sourcery-ai[bot]: end summary -->