### PR TITLE
ruff backup config

### DIFF
--- a/mackup/.config/ruff/ruff.toml
+++ b/mackup/.config/ruff/ruff.toml
@@ -1,0 +1,63 @@
+target-version = "py312"
+line-length = 99
+preview = true
+
+[lint]
+select = ["ALL"]
+fixable = ["ALL"]
+ignore = [
+    "ANN101",  # missing-type-self, deprecated
+    "ANN102",  # missing-type-cls, deprecated
+    "CPY001",  # missing-copyright-notice
+    "D100",  # undocumented-public-module
+    "D101",  # undocumented-public-class
+    "D102",  # undocumented-public-method
+    "D103",  # undocumented-public-function
+    "D104",  # undocumented-public-package
+    "D105",  # undocumented-magic-method
+    "D106",  # undocumented-public-nested-class
+    "D107",  # undocumented-public-init
+    "EM101",  # raw-string-in-exception
+    "EM102",  # f-string-in-exception
+    "ERA001",  # commented-out-code
+    "G001",  # logging-string-format
+    "G004",  # logging-f-string
+    "T201",  # print
+    "TRY003",  # raise-vanilla-args
+    # from https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",  # missing-trailing-comma
+    "COM819",  # prohibited-trailing-comma
+    "D206",  # indent-with-spaces
+    "D300",  # triple-single-quotes
+    "E111",  # indentation-with-invalid-multiple
+    "E114",  # indentation-with-invalid-multiple-comment
+    "E117",  # over-indented
+    "ISC001",  # single-line-implicit-string-concatenation
+    "ISC002",  # multi-line-implicit-string-concatenation
+    "Q000",  # bad-quotes-inline-string
+    "Q001",  # bad-quotes-multiline-string
+    "Q002",  # bad-quotes-docstring
+    "Q003",  # avoidable-escaped-quote
+    "W191",  # tab-indentation
+]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = [
+    "D100",  # undocumented-public-module
+    "D101",  # undocumented-public-class
+    "D102",  # undocumented-public-method
+    "D103",  # undocumented-public-function
+    "D104",  # undocumented-public-package
+    "D107",  # undocumented-public-init
+    "INP001",  # implicit-namespace-package
+    "S101",  # assert
+]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pycodestyle]
+max-doc-length = 80
+
+[format]
+docstring-code-format = true

--- a/mackup/.config/ruff/ruff.toml
+++ b/mackup/.config/ruff/ruff.toml
@@ -9,21 +9,22 @@ ignore = [
     "ANN101",  # missing-type-self, deprecated
     "ANN102",  # missing-type-cls, deprecated
     "CPY001",  # missing-copyright-notice
+    "D104",  # undocumented-public-package
+    "D107",  # undocumented-public-init
+    "EM101",  # raw-string-in-exception
+    "EM102",  # f-string-in-exception
+    "G001",  # logging-string-format
+    "G004",  # logging-f-string
+    "TRY003",  # raise-vanilla-args
+    # exclusions for quick-and-dirty scripts
     "D100",  # undocumented-public-module
     "D101",  # undocumented-public-class
     "D102",  # undocumented-public-method
     "D103",  # undocumented-public-function
-    "D104",  # undocumented-public-package
     "D105",  # undocumented-magic-method
     "D106",  # undocumented-public-nested-class
-    "D107",  # undocumented-public-init
-    "EM101",  # raw-string-in-exception
-    "EM102",  # f-string-in-exception
     "ERA001",  # commented-out-code
-    "G001",  # logging-string-format
-    "G004",  # logging-f-string
     "T201",  # print
-    "TRY003",  # raise-vanilla-args
     # from https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "COM812",  # missing-trailing-comma
     "COM819",  # prohibited-trailing-comma

--- a/mackup/.mackup.cfg
+++ b/mackup/.mackup.cfg
@@ -8,6 +8,7 @@ dotfiles
 git
 hyper
 mackup
+ruff
 ssh
 starship
 zsh

--- a/mackup/.mackup/ruff.cfg
+++ b/mackup/.mackup/ruff.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Ruff
+
+[xdg_configuration_files]
+ruff/ruff.toml


### PR DESCRIPTION
- backup base ruff config

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add Ruff configuration files to the mackup backup system, including a detailed Ruff configuration file specifying linting rules and formatting preferences.

New Features:
- Add configuration for Ruff to the mackup backup system, ensuring Ruff's settings are preserved.

<!-- Generated by sourcery-ai[bot]: end summary -->