### PR TITLE
add functionality to uninstall apps not in apps.toml

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -13,7 +13,6 @@ licecap = "cask"  # Animated screen capture application
 1351639930 = "mas"  # Gifski: Convert videos to quality GIFs
 
 [developer]
-awscli = "formula"  # Official Amazon AWS command-line interface
 charles = "cask"  # Web debugging Proxy application
 cursor = "cask"  # Write, edit, and chat about your code with AI
 docker = "cask"  # App to build and share containerised applications and microservices
@@ -25,6 +24,11 @@ shellcheck = "formula"  # Static analysis and lint tool, for (ba)sh scripts
 redis = "formula"  # Persistent key-value database, with built-in net interface
 visual-studio-code = "cask"  # Open-source code editor
 warp = "cask"  # Rust-based terminal
+
+[work]
+awscli = "formula"  # Official Amazon AWS command-line interface
+aws-sso-cli = "formula"  # Securely manage AWS API credentials using AWS SSO
+tunnelblick = "cask"  # Free and open-source OpenVPN client
 
 [fonts]
 font-eb-garamond = "cask"  # EB Garamond
@@ -67,7 +71,6 @@ google-drive = "cask"  # Client for the Google Drive storage service
 iina = "cask"  # Free and open-source media player [modern vlc alternative]
 istat-menus = "cask"  # System monitoring app
 notunes = "cask"  # Simple application that will prevent iTunes or Apple Music from launching
-openvpn-connect = "cask"  # Client program for the OpenVPN Access Server
 the-unarchiver = "cask"  # Unpacks archive files
 transmission = "cask"  # Open-source BitTorrent client
 937984704 = "mas"  # Amphetamine: Powerful keep-awake utility
@@ -127,5 +130,6 @@ yt-dlp = "formula"  # Feature-rich command-line audio/video downloader
 cowsay = "formula"  # Configurable talking characters in ASCII art
 lolcat = "formula"  # Rainbows and unicorns in your console!
 # Newer versions of system binaries
+bash = "formula"  # Bourne-Again SHell, a UNIX command interpreter
 git = "formula"  # Distributed revision control system
 grep = "formula"  # GNU grep, egrep and fgrep [command: ggrep]

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,7 @@ mas_sync() {
 		if [[ "$choice" == "y" ]]; then
 			for id in "${!missing_mas_apps[@]}"; do
 				name="${missing_mas_apps[$id]}"
+				# mas uninstall doesn't actually work so fall back to telling user to uninstall manually
 				if ! mas uninstall "$id"; then
 					echo -e "❌ \033[1;31mFailed to uninstall $name ($id). Please uninstall it manually.\033[0m"
 				else

--- a/install.sh
+++ b/install.sh
@@ -98,11 +98,21 @@ brew_sync() {
 
 	local missing_formulae=$(comm -23 <(brew leaves | sort) <(echo "$toml_apps" | sort))
 	local missing_casks=$(comm -23 <(brew list --cask | sort) <(echo "$toml_apps" | sort))
+	local missing_apps=$(echo -e "$missing_formulae\n$missing_casks" | sort -u)
 
-	if [[ -n "$missing_formulae" ]] || [[ -n "$missing_casks" ]]; then
+	if [[ -n "$missing_apps" ]]; then
 		echo -e "\n❗️ \033[1;31mThe following Homebrew-installed formulae and casks are missing from apps.toml:\033[0m"
 		echo "$missing_formulae" | sed 's/^/  /'
 		echo "$missing_casks" | sed 's/^/  /'
+		read -rp $'❓  \e[1;31mDo you want to uninstall these apps? (y/n) \e[0m ' choice
+		if [[ "$choice" == "y" ]]; then
+			for app in $missing_apps; do
+				brew uninstall "$app"
+				echo -e "\n🚮 \033[1;35mUninstalled $app.\033[0m"
+			done
+		else
+			echo -e "\n🆗 \033[1;35mNo apps were uninstalled.\033[0m"
+		fi
 	else
 		echo -e "\n✅ \033[1;32mAll Homebrew-installed formulae and casks are present in apps.toml.\033[0m"
 	fi
@@ -116,6 +126,15 @@ uv_sync() {
 	if [[ -n "$missing_uv_apps" ]]; then
 		echo -e "\n❗️ \033[1;31mThe following uv-installed apps are missing from apps.toml:\033[0m"
 		echo "$missing_uv_apps" | sed 's/^/  /'
+		read -rp $'❓  \e[1;31mDo you want to uninstall these apps? (y/n) \e[0m ' choice
+		if [[ "$choice" == "y" ]]; then
+			for app in $missing_uv_apps; do
+				uv tool uninstall "$app"
+				echo -e "\n🚮 \033[1;35mUninstalled $app.\033[0m"
+			done
+		else
+			echo -e "\n🆗 \033[1;35mNo apps were uninstalled.\033[0m"
+		fi
 	else
 		echo -e "\n✅ \033[1;32mAll uv-installed apps are present in apps.toml.\033[0m"
 	fi
@@ -126,16 +145,33 @@ mas_sync() {
 
 	local installed_mas_apps=$(mas list | sed -E 's/^([0-9]+)[[:space:]]+(.*)[[:space:]]+\(.*/\1 \2/' | sort)
 
-	local missing_mas_apps=""
+	# `-A` requires bash 4+, can't use Apple-provided bash which is 3.2
+	declare -A missing_mas_apps=()  # Ensure it's initialized as an empty associative array
+
 	while read -r id name; do
 		if ! echo "$toml_apps" | grep -q "^$id$"; then
-			missing_mas_apps+="\n$name ($id)"
+			missing_mas_apps["$id"]="$name"  # Store ID as key and app name as value
 		fi
 	done <<< "$installed_mas_apps"
 
-	if [[ -n "$missing_mas_apps" ]]; then
+	if [[ ${#missing_mas_apps[@]} -gt 0 ]]; then
 		echo -e "\n❗️ \033[1;31mThe following Mac App Store apps are missing from apps.toml:\033[0m"
-		echo -e "${missing_mas_apps/\\n/}"
+		for id in "${!missing_mas_apps[@]}"; do
+			echo -e "  ${missing_mas_apps[$id]} ($id)"
+		done
+		read -rp $'❓  \e[1;31mDo you want to uninstall these apps? (y/n) \e[0m ' choice
+		if [[ "$choice" == "y" ]]; then
+			for id in "${!missing_mas_apps[@]}"; do
+				name="${missing_mas_apps[$id]}"
+				if ! mas uninstall "$id"; then
+					echo -e "❌ \033[1;31mFailed to uninstall $name ($id). Please uninstall it manually.\033[0m"
+				else
+					echo -e "\n🚮 \033[1;35mUninstalled $name ($id).\033[0m"
+				fi
+			done
+		else
+			echo -e "\n🆗 \033[1;35mNo apps were uninstalled.\033[0m"
+		fi
 	else
 		echo -e "\n✅ \033[1;32mAll Mac App Store apps are present in apps.toml.\033[0m"
 	fi


### PR DESCRIPTION
- prompt using to uninstall apps that are not in apps.toml
- use tunnelblick instead of openvpn-connect
- update system bash
- create work section in apps.toml

## Summary by Sourcery

Introduce a feature to prompt users for uninstalling apps not present in apps.toml, enhancing system management. Replace openvpn-connect with tunnelblick for VPN client use and update the system bash to a newer version. Add a new 'work' section in apps.toml to categorize applications.

New Features:
- Add functionality to prompt users to uninstall apps not listed in apps.toml.

Enhancements:
- Switch from using openvpn-connect to tunnelblick for VPN client functionality.
- Update system bash to a newer version.