### PR TITLE
fix: Fix workflows

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -1,23 +1,35 @@
 ---
 name: Lint PR
 on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches: [main]
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
 
 jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   shellcheck:
-    name: Run shellcheck
+    name: shellcheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Display shellcheck version
+        run: shellcheck --version
       - name: shellcheck
-        uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: -x
-        with:
-          ignore_names: .zshrc .zprofile
+        run: shellcheck -x **/*.sh
   yamllint:
-    name: Run yamllint
+    name: yamllint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -1,21 +1,17 @@
 ---
 name: Validate Pull Request
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
-
-permissions:
-  pull-requests: read
+  pull_request:
+    branches: [main]
 
 jobs:
-  main:
-    name: Validate PR title
+  shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        uses: ludeeus/action-shellcheck@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHELLCHECK_OPTS: -x
+        with:
+          ignore_names: .zshrc .zprofile


### PR DESCRIPTION
- shellcheck was duplicated and not working

## Summary by Sourcery

Fix GitHub workflows by removing duplicate shellcheck job and updating event triggers and job configurations for lint_pr.yaml and validate_pr.yaml.

Bug Fixes:
- Fix duplicate shellcheck job in GitHub workflows.

CI:
- Update lint_pr.yaml to use pull_request_target event and add a job to validate PR titles.
- Switch validate_pr.yaml to use pull_request event and adjust shellcheck job configuration.