### PR TITLE
fix: Fix command to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ On a fresh (or not so fresh) macOS install, run the following command to install
 bash <(curl -L dot.lobao.io)
 ```
 
+To run the script without interactive prompts, run the following command:
+
+```bash
+curl -L http://dot.lobao.io | bash -s -- --yes
+```
+
 ### 1Password requirements
 
 1Password is required to store secrets used by these scripts. These include:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All these scripts are idempotent, meaning they can be run multiple times without
 On a fresh (or not so fresh) macOS install, run the following command to install Homebrew and run all scripts:
 
 ```bash
-curl -L http://dot.lobao.io | bash
+bash <(curl -L dot.lobao.io)
 ```
 
 ### 1Password requirements

--- a/dotsync.sh
+++ b/dotsync.sh
@@ -7,8 +7,6 @@ source "$(dirname "$0")/bash_traceback.sh"
 # UPDATE DOTFILES                                                             #
 ###############################################################################
 
-# echo -e "\033[1;34m🔗 Installing dotfiles...\033[0m"
-# sleep 1
 
 function dotlink() {
 	find "linkme" -type d -mindepth 1 | sed "s|^linkme/||" | \


### PR DESCRIPTION
- need to run it this way so it's interactive (https://stackoverflow.com/a/66880586/4760185)

## Summary by Sourcery

Fix the command in the README to run the script interactively and clean up the dotsync.sh script by removing commented-out code.

Bug Fixes:
- Correct the command in the README to ensure the script runs interactively.

Chores:
- Remove commented-out code from the dotsync.sh script.