### PR TITLE
feat: Add appsync function to run install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode,python
 # repo specific
 temp/
+.gitconfig.private

--- a/linkme/.exports
+++ b/linkme/.exports
@@ -24,3 +24,6 @@ export NNN_CONTEXT_COLORS='1234';
 
 # Change go path
 export GOPATH="$HOME/.go"
+
+# Add dotfiles (should match the one in bootstrap.sh)
+export DOTPATH="$HOME/.dotfiles"

--- a/linkme/.functions
+++ b/linkme/.functions
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Run .install.sh
+function appsync () {
+	bash "$DOTPATH/install.sh"
+}
+
 # Start screensaver.
 function ss () {
 	open -a ScreenSaverEngine


### PR DESCRIPTION
- new appsync function to run install.sh and sync installed apps with the ones in apps.toml
- export DOTPATH
- add gitconfig.private to gitignore

## Summary by Sourcery

Add a new AppSync function to run install.sh and sync applications with apps.toml, export DOTPATH, and update .gitignore to include gitconfig.private.

New Features:
- Introduce a new AppSync function to execute install.sh and synchronize installed applications with those listed in apps.toml.

Enhancements:
- Export DOTPATH in the environment configuration.

Chores:
- Add gitconfig.private to the .gitignore file to prevent it from being tracked.