### PR TITLE
fix: Fix base path for scripts

### DIFF
--- a/dock.sh
+++ b/dock.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Root is $DOTPATH if it exists, otherwise the directory of this script
+root=$(realpath "${DOTPATH:-$(dirname "$(realpath "$0")")}")
+
 # Source the bash_traceback.sh file
-source "$(dirname "$0")/bash_traceback.sh"
+source "$root/bash_traceback.sh"
 
 ###############################################################################
 # FUNCTIONS FOR MANIPULATING MACOS DOCK                                       #

--- a/dotsync.sh
+++ b/dotsync.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Root is $DOTPATH if it exists, otherwise the directory of this script
+root=$(realpath "${DOTPATH:-$(dirname "$(realpath "$0")")}")
+
 # Source the bash_traceback.sh file
-source "$(dirname "$0")/bash_traceback.sh"
+source "$root/bash_traceback.sh"
 
 ###############################################################################
 # UPDATE DOTFILES                                                             #

--- a/local.sh
+++ b/local.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Root is $DOTPATH if it exists, otherwise the directory of this script
+root=$(realpath "${DOTPATH:-$(dirname "$(realpath "$0")")}")
+
 # Source the bash_traceback.sh file
-source "$(dirname "$0")/bash_traceback.sh"
+source "$root/bash_traceback.sh"
 
 ###############################################################################
 # LOCAL SETTINGS AND VARIABLES                                                #

--- a/macos.sh
+++ b/macos.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Root is $DOTPATH if it exists, otherwise the directory of this script
+root=$(realpath "${DOTPATH:-$(dirname "$(realpath "$0")")}")
+
 # Source the bash_traceback.sh file
-source "$(dirname "$0")/bash_traceback.sh"
+source "$root/bash_traceback.sh"
 
 echo -e "\033[1;34m💻 Setting macOS preferences...\033[0m"
 

--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
+# Root is $DOTPATH if it exists, otherwise the directory of this script
+root=$(realpath "${DOTPATH:-$(dirname "$(realpath "$0")")}")
+
 # Source the bash_traceback.sh file
-source "$(dirname "$0")/bash_traceback.sh"
+source "$root/bash_traceback.sh"
 
 ###############################################################################
 # Install Homebrew                                                            #
 ###############################################################################
-echo -e "\033[1;34m🍺 Installing Homebrew...\033[0m"
+echo
+echo -e "\033[1;33m🍺 Installing Homebrew...\033[0m"
 if ! command -v brew &> /dev/null; then
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	echo -e "🍻 \033[1;32mHomebrew installed.\033[0m"
@@ -17,32 +21,36 @@ fi
 ###############################################################################
 # Install dotfiles                                                            #
 ###############################################################################
-sleep 1
 echo
+echo -e "\033[1;33m🚀 Running dotsync.sh...\033[0m"
+sleep 1
 ./dotsync.sh "${1:-}"
 
 ###############################################################################
 # Local settings and variables                                                #
 ###############################################################################
-sleep 1
 echo
+echo -e "\033[1;33m🚀 Running local.sh...\033[0m"
+sleep 1
 ./local.sh "${1:-}"
 
 ###############################################################################
 # macOS preferences                                                           #
 ###############################################################################
 # sleep 1
-# echo
+# echo -e "\033[1;33m🚀 Running macos.sh...\033[0m"
 # sudo ./macos.sh
 
 ###############################################################################
 # Install apps and software                                                   #
 ###############################################################################
-sleep 1
 echo
+echo -e "\033[1;33m🚀 Running install.sh...\033[0m"
+sleep 1
 ./install.sh "${1:-}"
-sleep 1
 echo
+echo -e "\033[1;33m🚀 Running dock.sh...\033[0m"
+sleep 1
 ./dock.sh
 
 echo


### PR DESCRIPTION
- use DOTPATH if it exists
- minor visual changes

## Summary by Sourcery

Fix the base path for scripts by using DOTPATH if available and enhance visual feedback with updated echo statements.

Bug Fixes:
- Fix the base path for scripts by using the DOTPATH environment variable if it exists, otherwise defaulting to the script's directory.

Enhancements:
- Improve visual feedback in scripts by updating echo statements with new color codes.