### PR TITLE
feat: Send notification for long-running tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Several people and repositories have contributed to or been a source of inspirat
 - [@kevinsuttle](https://kevinsuttle.com/)/[macOS-Defaults](https://github.com/kevinSuttle/macOS-Defaults)
 - [@ryanpavlick](https://github.com/rpavlick)/[add_to_dock](https://github.com/rpavlick/add_to_dock)
 - [@MichaelAquilina](https://github.com/MichaelAquilina)/[zsh-auto-notify](https://github.com/MichaelAquilina/zsh-auto-notify)
-- [@kniraj](https://github.com/Niraj-Kamdar)/[macos-the-long-running-task-notifier](https://dev.to/kniraj/macos-the-long-running-task-notifier-35o1)
+- [@Niraj-Kamdar](https://github.com/Niraj-Kamdar)/[macos-the-long-running-task-notifier](https://dev.to/kniraj/macos-the-long-running-task-notifier-35o1)
 - [@ikuwow](https://github.com/ikuwow)/[dotfiles](https://github.com/ikuwow/dotfiles)
 - [@kennethreitz](https://www.kennethreitz.org/)/[dotfiles](https://github.com/kennethreitz/dotfiles)
 - [@br3ndonland](https://github.com/br3ndonland)/[dotfiles](https://github.com/br3ndonland/dotfiles)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Several people and repositories have contributed to or been a source of inspirat
 - [@mathiasbyens](https://mathiasbynens.be/)/[dotfiles](https://github.com/mathiasbynens/dotfiles), off of which this repository was initially based
 - [@kevinsuttle](https://kevinsuttle.com/)/[macOS-Defaults](https://github.com/kevinSuttle/macOS-Defaults)
 - [@ryanpavlick](https://github.com/rpavlick)/[add_to_dock](https://github.com/rpavlick/add_to_dock)
+- [@MichaelAquilina](https://github.com/MichaelAquilina)/[zsh-auto-notify](https://github.com/MichaelAquilina/zsh-auto-notify)
+- [@kniraj](https://github.com/Niraj-Kamdar)/[macos-the-long-running-task-notifier](https://dev.to/kniraj/macos-the-long-running-task-notifier-35o1)
 - [@ikuwow](https://github.com/ikuwow)/[dotfiles](https://github.com/ikuwow/dotfiles)
 - [@kennethreitz](https://www.kennethreitz.org/)/[dotfiles](https://github.com/kennethreitz/dotfiles)
 - [@br3ndonland](https://github.com/br3ndonland)/[dotfiles](https://github.com/br3ndonland/dotfiles)

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -153,10 +153,8 @@ function command_end {
 				return
 			fi
 		done
-		local cmd_title="${command%% *}"
-		cmd_title="$(tr '[:lower:]' '[:upper:]' <<< ${cmd_title:0:1})${cmd_title:1}"
 		local message="'${zsh_last_command}' finished after ${duration}s"
-		local title="${cmd_title} Command Completed"
+		local title="Terminal Command Completed"
 		osascript -e "display notification \"$message\" with title \"$title\""
 	fi
 }

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -148,9 +148,11 @@ function command_end {
 			"vim"
 			"watch"
 		)
-		if [[ " ${notify_exclude[@]} " =~ " ${command} "* ]]; then
-			return
-		fi
+		for exclude in "${notify_exclude[@]}"; do
+			if [[ "$command" == "$exclude"* ]]; then
+				return
+			fi
+		done
 		local cmd_title="${command%% *}"
 		cmd_title="$(tr '[:lower:]' '[:upper:]' <<< ${cmd_title:0:1})${cmd_title:1}"
 		local message="'${zsh_last_command}' finished after ${duration}s"

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -71,6 +71,10 @@ HIST_STAMPS="yyyy-mm-dd"
 # Would you like to use another custom folder than $ZSH/custom?
 ZSH_CUSTOM=$ZSH/custom
 
+# Activate Homebrew-installed plugins
+source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
 # Which plugins would you like to load?
 # Standard plugins can be found in $ZSH/plugins/
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
@@ -97,13 +101,64 @@ unset file;
 # 1Password completion
 eval "$(op completion zsh)"; compdef _op op
 
-# Activate Homebrew-installed plugins
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-
 # Starship complettion
 eval "$(starship init zsh)"
 
 # Shell completion for uv and uvx
 eval "$(uv generate-shell-completion zsh)"
 eval "$(uvx --generate-shell-completion zsh)"
+
+# Notify for long running commands
+# https://dev.to/kniraj/macos-the-long-running-task-notifier-35o1
+# https://github.com/MichaelAquilina/zsh-auto-notify
+function command_start {
+	zsh_command_start_time=$SECONDS
+	zsh_last_command=$1
+}
+
+function command_end {
+	local duration=$((SECONDS - zsh_command_start_time))
+	if (( duration > 30 )); then
+		# Split the command if its been piped one or more times
+		local command_list=("${(@s/|/)${zsh_last_command}}")
+		local command="${command_list[-1]}"
+		# Remove leading whitespace
+		command="$(echo "$command" | sed -e 's/^ *//')"
+		# Remove sudo prefix from command if detected
+		if [[ "$command" == "sudo "* ]]; then
+			command="${command/sudo /}"
+		fi
+
+		# Don't notify for SSH commands
+		if [[ -n ${SSH_CLIENT-} || -n ${SSH_TTY-} || -n ${SSH_CONNECTION-} ]]; then
+			return
+		fi
+		# Don't notify for these commands
+		local notify_exclude=(
+			"git diff"
+			"htop"
+			"ipython"
+			"less"
+			"man"
+			"more"
+			"nano"
+			"python"
+			"ssh"
+			"top"
+			"vim"
+			"watch"
+		)
+		if [[ " ${notify_exclude[@]} " =~ " ${command} "* ]]; then
+			return
+		fi
+		local cmd_title="${command%% *}"
+		cmd_title="$(tr '[:lower:]' '[:upper:]' <<< ${cmd_title:0:1})${cmd_title:1}"
+		local message="'${zsh_last_command}' finished after ${duration}s"
+		local title="${cmd_title} Command Completed"
+		osascript -e "display notification \"$message\" with title \"$title\""
+	fi
+}
+
+autoload -U add-zsh-hook
+add-zsh-hook preexec command_start
+add-zsh-hook precmd command_end


### PR DESCRIPTION
- send a notification on macOS for commands that take longer than 30 seconds to run
- ignore a few false positives, like `ssh` or `python`

## Summary by Sourcery

Introduce a feature to notify users on macOS for commands running longer than 30 seconds, excluding certain commands like 'ssh' and 'python'. Reorganize the .zshrc file for improved plugin activation clarity and update the README with relevant project references.

New Features:
- Implement a notification system for macOS that alerts users when a command takes longer than 30 seconds to execute.

Enhancements:
- Reorganize the activation of Homebrew-installed plugins in the .zshrc file for better clarity.

Documentation:
- Add references to the zsh-auto-notify and macos-the-long-running-task-notifier projects in the README.md as sources of inspiration.