### PR TITLE
feat: Add more commands to ignore for auto-notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Several people and repositories have contributed to or been a source of inspirat
 - [@br3ndonland](https://github.com/br3ndonland)/[dotfiles](https://github.com/br3ndonland/dotfiles)
 - [@pablopunk](https://github.com/pablopunk)/[dotfiles](https://github.com/pablopunk/dotfiles)
 - [@demophoon](https://github.com/demophoon)/[dotfiles](https://github.com/demophoon/dotfiles)
+- [@lupin3000](https://github.com/lupin3000)/[macOS-defaults](https://lupin3000.github.io/macOS/defaults/)

--- a/linkme/.oh-my-zsh/custom/plugins/auto-notify/auto-notify.plugin.zsh
+++ b/linkme/.oh-my-zsh/custom/plugins/auto-notify/auto-notify.plugin.zsh
@@ -16,20 +16,22 @@
 # List of commands/programs to ignore sending notifications for
 [[ -z "$AUTO_NOTIFY_IGNORE" ]] &&
 	export AUTO_NOTIFY_IGNORE=(
-		'vim'
-		'nvim'
-		'less'
-		'more'
-		'man'
-		'tig'
-		'watch'
 		'git commit'
-		'top'
+		'git diff'
+		'git log'
 		'htop'
-		'ssh'
-		'nano'
 		'ipython'
+		'less'
+		'man'
+		'more'
+		'nano'
+		'nvim'
 		'python'
+		'ssh'
+		'tig'
+		'top'
+		'vim'
+		'watch'
 	)
 
 function _auto_notify_format() {


### PR DESCRIPTION
- add `git diff` and `git log` to AUTO_NOTIFY_IGNORE
- add macOS defaults link to inspiration in readme

## Summary by Sourcery

Enhance the auto-notify plugin by adding 'git diff' and 'git log' to the list of ignored commands and update the README with a new inspiration link for macOS defaults.

New Features:
- Add 'git diff' and 'git log' to the list of commands ignored by the auto-notify plugin.

Documentation:
- Add a link to the macOS defaults inspiration in the README.