### PR TITLE
chore: Clean up and zap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,7 @@ brew_sync() {
 		fi
 		if [[ ${choice} == "y" ]]; then
 			for app in ${missing_apps}; do
-				brew uninstall "${app}"
+				brew uninstall --zap "${app}"
 				echo -e "🚮 \033[1;35mUninstalled ${app}.\033[0m"
 			done
 		else

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -10,18 +10,6 @@ if [ ! -d "$ZSH" ]; then
 	sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 fi
 
-# Set name of the theme to load --- if set to "random", it will
-# load a random theme each time oh-my-zsh is loaded, in which case,
-# to know which specific one was loaded, run: echo $RANDOM_THEME
-# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="robbyrussell"
-
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in $ZSH/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
-
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 


### PR DESCRIPTION
- use `brew uninstall --zap` when removing apps and formula
- remove unused oh-my-zsh theme

## Summary by Sourcery

Clean up the configuration by removing an unused oh-my-zsh theme and enhance the uninstall process by using 'brew uninstall --zap' for a more comprehensive removal of apps and formulae.

Enhancements:
- Use 'brew uninstall --zap' for removing apps and formulae to ensure a more thorough cleanup.

Chores:
- Remove unused oh-my-zsh theme from configuration.