### PR TITLE
chore: Ruff and trunk settings

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -33,6 +33,5 @@ lint:
 actions:
   enabled:
     - trunk-announce
-    - trunk-check-pre-push
     - trunk-fmt-pre-commit
     - trunk-upgrade-available

--- a/linkme/.config/ruff/ruff.toml
+++ b/linkme/.config/ruff/ruff.toml
@@ -6,8 +6,6 @@ preview = true
 select = ["ALL"]
 fixable = ["ALL"]
 ignore = [
-  "ANN101", # missing-type-self, deprecated
-  "ANN102", # missing-type-cls, deprecated
   "CPY001", # missing-copyright-notice
   "D104", # undocumented-public-package
   "D107", # undocumented-public-init

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -93,6 +93,7 @@ eval "$(op completion zsh)"; compdef _op op
 # Starship complettion
 eval "$(starship init zsh)"
 
-# Shell completion for uv and uvx
+# Shell completion for uv, uvx, and ruff
 eval "$(uv generate-shell-completion zsh)"
 eval "$(uvx --generate-shell-completion zsh)"
+eval "$(ruff generate-shell-completion zsh)"


### PR DESCRIPTION
- add ruff to shell completion
- remove deprecated ruff rules
- remove trunk pre-commit hook for push

## Summary by Sourcery

Update shell completion to include Ruff, clean up deprecated Ruff rules, and remove the trunk pre-commit hook for push.

Enhancements:
- Remove deprecated Ruff rules from the configuration file.

CI:
- Remove the trunk pre-commit hook for push from the trunk configuration.

Chores:
- Add Ruff to shell completion in the zsh configuration.