### PR TITLE
feat: Add Brother iPrint&Scan app

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -82,6 +82,7 @@ raycast = "cask" # Control your tools with a few keystrokes
 rocket = "cask" # Emoji picker optimised for blind people
 the-unarchiver = "cask" # Unpacks archive files
 transmission = "cask" # Open-source BitTorrent client
+1193539993 = "mas" # Brother iPrint&Scan
 937984704 = "mas" # Amphetamine: Powerful keep-awake utility
 
 [utilities]


### PR DESCRIPTION
- used for brother ADS-1250W scanner (do not recommend)

## Summary by Sourcery

New Features:
- Add support for Brother iPrint&Scan app.