### PR TITLE
feat: Disable pushing directly to main or master

### DIFF
--- a/linkme/.gitconfig
+++ b/linkme/.gitconfig
@@ -19,6 +19,12 @@
 	sort = -committerdate
 	autoSetupMerge = simple
 
+[branch "main"]
+	pushRemote = you_have_disabled_push_for_this_branch_in_your_global_gitconfig
+
+[branch "master"]
+	pushRemote = you_have_disabled_push_for_this_branch_in_your_global_gitconfig
+
 [diff]
 	# Detect copies as well as renames.
 	renames = copies


### PR DESCRIPTION
- disallows any pushing directly to main or master on any repo

## Summary by Sourcery

CI:
- Disallow pushing directly to the main or master branch.