### PR TITLE
feat: Ghostty

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2018-2024 Martim Lobao <https://martimlobao.com>
+Copyright (c) Martim Lobao <https://martimlobao.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps.toml
+++ b/apps.toml
@@ -17,6 +17,7 @@ charles = "cask" # Web debugging Proxy application
 cursor = "cask" # Write, edit, and chat about your code with AI
 docker = "cask" # App to build and share containerised applications and microservices
 gh = "formula" # GitHub command-line tool
+ghostty = "cask" # Terminal emulator that uses platform-native UI and GPU acceleration
 hyper = "cask" # Terminal built on web technologies
 jupyter-notebook-viewer = "cask" # Utility to render Jupyter notebooks
 lm-studio = "cask" # Discover, download, and run local LLMs

--- a/dock.sh
+++ b/dock.sh
@@ -159,7 +159,7 @@ add_app_to_dock "Todoist"
 add_app_to_dock "Linear"
 add_app_to_dock "Slack"
 add_app_to_dock "Cursor"
-add_app_to_dock "Hyper"
+add_app_to_dock "Ghostty"
 add_app_to_dock "System Settings"
 add_folder_to_dock "${HOME}/Downloads" --sortby 2 --displayas 1 --viewcontentas 1
 

--- a/linkme/.config/ghostty/config
+++ b/linkme/.config/ghostty/config
@@ -1,0 +1,43 @@
+# title = " "
+confirm-close-surface = false
+quit-after-last-window-closed = true
+shell-integration = none
+shell-integration-features = no-cursor
+scrollback-limit = 10000000
+clipboard-read = allow
+copy-on-select = false
+window-colorspace = display-p3
+window-padding-x = 16
+window-padding-y = 8
+window-padding-balance = true
+theme = Snazzy Soft
+background = #282a36
+foreground = #eff0eb
+selection-background = #92bcd0
+selection-foreground = #000000
+cursor-color = #eaeaea
+cursor-text = #282a36
+cursor-style = block
+cursor-style-blink = false
+palette = 0=#000000
+palette = 1=#ff5c57
+palette = 2=#5af78e
+palette = 3=#f3f99d
+palette = 4=#57c7ff
+palette = 5=#ff6ac1
+palette = 6=#9aedfe
+palette = 7=#f1f1f0
+palette = 8=#686868
+palette = 9=#ff5c57
+palette = 10=#5af78e
+palette = 11=#f3f99d
+palette = 12=#57c7ff
+palette = 13=#ff6ac1
+palette = 14=#9aedfe
+palette = 15=#f1f1f0
+font-size = 12
+font-thicken = true
+font-family = Source Code Pro
+keybind = cmd+backspace=esc:w
+macos-titlebar-style = tabs
+macos-titlebar-proxy-icon = hidden

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -35,7 +35,7 @@ zstyle ':omz:update' frequency 14
 DISABLE_AUTO_TITLE="true"
 precmd() {
 	FOLDER=$( [[ "$PWD" == "$HOME" ]] && echo '~' || basename "$PWD" )
-	eval "echo -ne '\033]0;${USER}@${HOST}:${FOLDER}\007'"
+	eval "echo -ne '\033]0;${FOLDER}\007'"
 }
 
 

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -32,7 +32,12 @@ zstyle ':omz:update' frequency 14
 # DISABLE_LS_COLORS="true"
 
 # Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
+DISABLE_AUTO_TITLE="true"
+precmd() {
+	FOLDER=$( [[ "$PWD" == "$HOME" ]] && echo '~' || basename "$PWD" )
+	eval "echo -ne '\033]0;${USER}@${HOST}:${FOLDER}\007'"
+}
+
 
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -35,7 +35,7 @@ zstyle ':omz:update' frequency 14
 DISABLE_AUTO_TITLE="true"
 precmd() {
 	FOLDER=$( [[ "$PWD" == "$HOME" ]] && echo '~' || basename "$PWD" )
-	eval "echo -ne '\033]0;${FOLDER}\007'"
+	printf '\033]0;%s\007' "${FOLDER}"
 }
 
 


### PR DESCRIPTION
- add Ghostty
- configure Ghostty to mimick Hyper appearance

## Summary by Sourcery

Replace Hyper with Ghostty as the default terminal emulator.

Enhancements:
- Disable automatic terminal title setting and add a custom pre-command to display the current folder in the terminal title.

Chores:
- Update the copyright year in LICENSE.md.