### PR TITLE
chore: Cleanup and docstring settings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -134,6 +134,7 @@ brew_sync() {
 		fi
 		if [[ ${choice} == "y" ]]; then
 			for app in ${missing_apps}; do
+				echo -e "🗑️ \033[1;35mUninstalling ${app}...\033[0m"
 				brew uninstall --zap "${app}"
 				echo -e "🚮 \033[1;35mUninstalled ${app}.\033[0m"
 			done

--- a/linkme/.code/docstring.mustache
+++ b/linkme/.code/docstring.mustache
@@ -1,0 +1,42 @@
+{{summaryPlaceholder}}
+
+{{#placeholder}}[extended_summary]{{/placeholder}}
+
+{{#parametersExist}}
+Args:
+{{#args}}
+    {{var}} ({{typePlaceholder}}): {{descriptionPlaceholder}}
+{{/args}}
+{{#kwargs}}
+    {{var}} ({{typePlaceholder}}, optional): {{descriptionPlaceholder}}. Defaults to {{&default}}.
+{{/kwargs}}
+{{/parametersExist}}
+
+{{#returnsExist}}
+Returns:
+{{#returns}}
+    {{typePlaceholder}}: {{descriptionPlaceholder}}
+{{/returns}}
+{{/returnsExist}}
+
+{{#exceptionsExist}}
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}
+{{/exceptions}}
+{{/exceptionsExist}}
+
+Examples:
+    >>> {{name}}({{#args}}{{var}}, {{/args}}{{#kwargs}}{{var}}, {{/kwargs}})
+    {{#placeholder}}[output]{{/placeholder}}
+    >>> {{name}}({{#args}}{{var}}, {{/args}}{{#kwargs}}{{var}}, {{/kwargs}})
+    {{#placeholder}}[output]{{/placeholder}}
+
+Notes:
+    {{#placeholder}}[notes]{{/placeholder}}
+
+TODO (D-{{#placeholder}}[ticket_number]{{/placeholder}}):
+    {{#placeholder}}[todo]{{/placeholder}}
+
+.. {{#placeholder}}[reference_name]{{/placeholder}}:
+    {{#placeholder}}[url]{{/placeholder}}

--- a/linkme/.functions
+++ b/linkme/.functions
@@ -45,7 +45,7 @@ function c() {
 	if [[ $# -eq 0 ]]; then
 		cursor .
 	else
-		open "$@"
+		cursor "$@"
 	fi
 }
 

--- a/linkme/.gitconfig
+++ b/linkme/.gitconfig
@@ -57,9 +57,10 @@
 	rebase = false
 
 [alias]
+	s = status
 	unstage = reset HEAD --
 	uncommit = reset --soft HEAD~
-	# Generate a default gitgnore file (e.g. `git ignore ruby c > .gitignore`).
+	# Generate a default gitignore file (e.g. `git ignore ruby c > .gitignore`).
 	# Defaults to Python, macOS, Pants, and Visual Studio Code.
 	ignore = "!gi() { curl -sL https://www.toptal.com/developers/gitignore/api/${@:-macos,visualstudiocode,python,pants} ;}; gi"
 	# Delete all squashed branches.

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,16 @@ echo -e "\033[1;33m💻 OS detected:\033[0m   ${os}"
 archname="$(arch)"
 echo -e "\033[1;33m💻 Arch detected:\033[0m ${archname}"
 
+# Get hardware identifier
+if [[ ${os} == "Darwin" ]]; then
+	HARDWARE_UUID=$(system_profiler SPHardwareDataType | awk '/Hardware UUID/ {print $3}')
+else
+	HARDWARE_UUID=$(cat /sys/class/dmi/id/product_uuid 2>/dev/null ||
+		cat /etc/machine-id 2>/dev/null ||
+		cat /var/lib/dbus/machine-id 2>/dev/null)
+fi
+echo -e "\033[1;33m💻 Hardware UUID:\033[0m ${HARDWARE_UUID}"
+
 ###############################################################################
 # Install Homebrew                                                            #
 ###############################################################################


### PR DESCRIPTION
- fix c function
- print UUID on run.sh
- store docstring.mustache file
- cleanup

## Summary by Sourcery

Add hardware UUID to run.sh output, uninstall missing apps before installing during brew sync, and add a docstring template file.

Enhancements:
- Print the hardware UUID in the run.sh script.
- Uninstall missing apps before installing them during brew sync.

Chores:
- Store a docstring template file in the .code directory.
- Clean up unused files.