### PR TITLE
feat: Support for older versions of macOS

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -1,6 +1,8 @@
-[base]
+[core]
 mas = "formula" # Mac App Store command-line interface
 uv = "formula" # Extremely fast Python package installer and resolver, written in Rust
+1password = "cask" # Password manager that keeps all passwords secure behind one password
+1password-cli = "cask" # Command-line interface for 1Password [command: op]
 
 [apple]
 408981434 = "mas" # iMovie: Make your own movie magic
@@ -65,7 +67,6 @@ telegram = "cask" # Messaging app with a focus on speed and security
 whatsapp = "cask" # Native desktop client for WhatsApp
 
 [tools]
-1password = "cask" # Password manager that keeps all passwords secure behind one password
 arc = "cask" # Chromium based browser
 calibre = "cask" # E-books management software
 dropbox = "cask" # Client for the Dropbox cloud storage service
@@ -108,7 +109,7 @@ rust = "formula" # Safe, concurrent, practical language
 ipython = "uv" # Interactive computing in Python
 marimo = "uv" # Reactive notebook for Python [Jupyter alternative]
 mypy = "uv" # Experimental optional static type checker for Python
-pants = "cask" # Fast, scalable, user-friendly build system for codebases of all sizes
+"pantsbuild/tap/pants" = "cask" # Fast, scalable, user-friendly build system for codebases of all sizes
 poetry = "uv" # Python package management tool
 pylint = "uv" # It's not just a linter that annoys you!
 ruff = "uv" # Extremely fast Python linter, written in Rust
@@ -119,7 +120,6 @@ apache-spark = "formula" # Engine for large-scale data processing
 temurin = "cask" # JDK from the Eclipse Foundation (Adoptium) [simpler setup than installing openjdk@11 and symlinking]
 
 [cli-tools]
-1password-cli = "cask" # Command-line interface for 1Password [command: op]
 ack = "formula" # Search tool like grep, but optimized for programmers
 bat = "formula" # Clone of cat(1) with syntax highlighting and Git integration
 exiftool = "formula" # Perl lib for reading and writing EXIF metadata

--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,9 @@ install() {
 brew_sync() {
 	local toml_apps
 	toml_apps=$(yq eval 'to_entries | map(.value | to_entries | map(select(.value == "cask" or .value == "formula") | .key)) | flatten | .[]' "${apps_toml}")
+	toml_apps_without_taps=$(echo "${toml_apps}" | sed -E 's|.*/||') # get name from tapped apps (slashes in name)
+	# combine toml_apps_without_taps with toml_apps
+	toml_apps=$(echo -e "${toml_apps_without_taps}\n${toml_apps}" | sort -u)
 
 	local missing_formulae
 	missing_formulae=$(comm -23 <(brew leaves | sort) <(echo "${toml_apps}" | sort))

--- a/linkme/.zprofile
+++ b/linkme/.zprofile
@@ -5,7 +5,12 @@ fi
 
 # Homebrew on macOS or Linux
 if [[ "$(uname)" == "Darwin" ]]; then
-	eval "$(/opt/homebrew/bin/brew shellenv)"
+	if [[ -f /opt/homebrew/bin/brew ]]; then
+		eval "$(/opt/homebrew/bin/brew shellenv)"
+	else
+		# for old versions of macOS
+		eval "$(/usr/local/bin/brew shellenv)"
+	fi
 else
 	eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -5,9 +5,11 @@
 export ZSH="$HOME/.oh-my-zsh"
 
 # Install oh-my-zsh if it isn't installed yet
-if [ ! -d "$ZSH" ]; then
+if [ ! -f "$ZSH/oh-my-zsh.sh" ]; then
 	echo -e "⬇️  \033[1;34mInstalling oh-my-zsh...\033[0m" # needs 2 spaces after emoji
-	sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+	echo -e "❗️  \033[1;31mDeleting ${ZSH}, please sync dotfiles after finishing.\033[0m"
+	rm -r $ZSH
+	ZSH= sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 fi
 
 # Uncomment the following line to use case-sensitive completion.

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -7,8 +7,11 @@ export ZSH="$HOME/.oh-my-zsh"
 # Install oh-my-zsh if it isn't installed yet
 if [ ! -f "$ZSH/oh-my-zsh.sh" ]; then
 	echo -e "⬇️  \033[1;34mInstalling oh-my-zsh...\033[0m" # needs 2 spaces after emoji
-	echo -e "❗️  \033[1;31mDeleting ${ZSH}, please sync dotfiles after finishing.\033[0m"
-	rm -r $ZSH
+	if [ -d "$ZSH" ]; then
+		echo -e "❗️ \033[1;31mMoving ${ZSH} to ${ZSH}.bak, please sync dotfiles after finishing.\033[0m"
+		cp -r $ZSH $ZSH.bak
+		rm -rf $ZSH
+	fi
 	ZSH= sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 fi
 
@@ -40,7 +43,6 @@ precmd() {
 	printf '\033]0;%s\007' "${FOLDER}"
 }
 
-
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"
 
@@ -66,10 +68,6 @@ HIST_STAMPS="yyyy-mm-dd"
 # Would you like to use another custom folder than $ZSH/custom?
 ZSH_CUSTOM=$ZSH/custom
 
-# Activate Homebrew-installed plugins
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-
 # Which plugins would you like to load?
 # Standard plugins can be found in $ZSH/plugins/
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
@@ -81,9 +79,11 @@ plugins=(
 	autojump
 	git
 	thefuck
-	zsh-autosuggestions
-	zsh-syntax-highlighting
 )
+
+# Activate Homebrew-installed plugins
+source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
 source $ZSH/oh-my-zsh.sh
 

--- a/local.sh
+++ b/local.sh
@@ -14,13 +14,13 @@ echo -e "🔑 \033[1;34mSetting local settings and variables...\033[0m"
 
 # ensure signed in to 1Password
 echo -e "🔐 \033[1;35mSigning in to 1Password...\033[0m"
-if [[ -z $(op account get 2>/dev/null) ]]; then
+if [[ -z "$(op account get 2>/dev/null)" ]]; then
 	echo -e "ℹ️  \033[1;33mSigning in to 1Password for the first time, please follow the instructions and enable the SSH Agent in the 1Password app.\033[0m"
 	op signin --help
 	open /Applications/1Password.app
-	eval $(op account add --address my.1password.com)
+	eval "$(op account add --address my.1password.com)"
 fi
-eval $(op signin)
+eval "$(op signin)"
 
 # Set up .gitconfig.private
 echo -e "📝 \033[1;35mSetting up .gitconfig.private...\033[0m"

--- a/local.sh
+++ b/local.sh
@@ -14,7 +14,13 @@ echo -e "🔑 \033[1;34mSetting local settings and variables...\033[0m"
 
 # ensure signed in to 1Password
 echo -e "🔐 \033[1;35mSigning in to 1Password...\033[0m"
-op signin
+if [[ -z $(op account get) ]]; then
+	eval $(op account add --address my.1password.com)
+	eval $(op signin --help)
+	echo "Also set up SSH Agent"
+	open /Applications/1Password.app
+fi
+eval $(op signin)
 
 # Set up .gitconfig.private
 echo -e "📝 \033[1;35mSetting up .gitconfig.private...\033[0m"

--- a/local.sh
+++ b/local.sh
@@ -14,11 +14,11 @@ echo -e "🔑 \033[1;34mSetting local settings and variables...\033[0m"
 
 # ensure signed in to 1Password
 echo -e "🔐 \033[1;35mSigning in to 1Password...\033[0m"
-if [[ -z $(op account get) ]]; then
-	eval $(op account add --address my.1password.com)
-	eval $(op signin --help)
-	echo "Also set up SSH Agent"
+if [[ -z $(op account get 2>/dev/null) ]]; then
+	echo -e "ℹ️  \033[1;33mSigning in to 1Password for the first time, please follow the instructions and enable the SSH Agent in the 1Password app.\033[0m"
+	op signin --help
 	open /Applications/1Password.app
+	eval $(op account add --address my.1password.com)
 fi
 eval $(op signin)
 


### PR DESCRIPTION
- old brew directory
- sign in properly on 1Password on new machines
- set up oh-my-zsh properly
- set up homebrew oh-my-zsh plugins properly
- revert change for brew taps

## Summary by Sourcery

Update Homebrew configurations, 1Password setup, and Oh My Zsh installation.

Enhancements:
- Move 1Password and its CLI to the core section in apps.toml.

Build:
- Install core formulae and casks, including 1Password and its CLI.
- Support older macOS versions by checking for alternative Homebrew paths.
- Reinstall Oh My Zsh if the directory exists but oh-my-zsh.sh is missing.

Chores:
- Sign in to 1Password during the setup process, prompting the user to enable the SSH Agent if it is the first time signing in.