### PR TITLE
chore: Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Here's a short description of each script in this repository:
 - `macos.sh` configure several macOS settings
 - `install.sh` install fonts, tools, and apps using Homebrew, [`uv`](https://docs.astral.sh/uv/), and the Mac App Store
 - `dock.sh` configure macOS dock
+- `code.sh` install Cursor extensions
 - `local.sh` final local settings, like configuring git user details and registering apps using keys stored in 1Password
 - `bash_traceback.sh` helper script used by other scripts to print a more helpful traceback on failure (does nothing by itself)
 

--- a/code.sh
+++ b/code.sh
@@ -23,13 +23,13 @@ done
 extensions_file="${root}/linkme/.config/code/extensions.txt"
 
 export_extensions() {
-	printf "\n📲 \033[1;34mExporting extensions from %s to extensions.txt...\033[0m\n\n" "$2"
+	printf "📲 \033[1;34mExporting extensions from %s to extensions.txt...\033[0m\n\n" "$2"
 	$1 --list-extensions >"${extensions_file}"
 	printf "✅ \033[1;32mExtensions exported to extensions.txt\033[0m\n"
 }
 
 sync_extensions() {
-	printf "\n📲 \033[1;34mSyncing extensions for %s...\033[0m\n\n" "$2"
+	printf "📲 \033[1;34mSyncing extensions for %s...\033[0m\n\n" "$2"
 	local installed to_remove=()
 
 	# Get currently installed extensions

--- a/linkme/.config/code/extensions.txt
+++ b/linkme/.config/code/extensions.txt
@@ -1,5 +1,4 @@
 1password.op-vscode
-ban.spellright
 batisteo.vscode-django
 bierner.emojisense
 bierner.markdown-mermaid
@@ -10,14 +9,12 @@ davidanson.vscode-markdownlint
 dbaeumer.vscode-eslint
 dnicolson.binary-plist
 donjayamanne.githistory
-donjayamanne.python-environment-manager
 donjayamanne.python-extension-pack
 dorzey.vscode-sqlfluff
 dotjoshjohnson.xml
 eamodio.gitlens
 eliverlara.andromeda
 esbenp.prettier-vscode
-file-icons.file-icons
 formulahendry.code-runner
 github.remotehub
 github.vscode-github-actions
@@ -63,7 +60,6 @@ njpwerner.autodocstring
 pnp.polacode
 redhat.vscode-yaml
 richie5um2.vscode-sort-json
-searking.preview-vscode
 snowflake.snowflake-vsc
 stkb.rewrap
 streetsidesoftware.code-spell-checker

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -74,18 +74,29 @@ ZSH_CUSTOM=$ZSH/custom
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
-	1password
 	auto-notify
 	autojump
 	git
 	thefuck
 )
 
+source $ZSH/oh-my-zsh.sh
+
 # Activate Homebrew-installed plugins
 source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
-source $ZSH/oh-my-zsh.sh
+# 1Password completion and plugins
+eval "$(op completion zsh)"; compdef _op op
+source "$HOME/.config/op/plugins.sh"
+
+# Starship completion
+eval "$(starship init zsh)"
+
+# Shell completion for uv, uvx, and ruff
+eval "$(uv generate-shell-completion zsh)"
+eval "$(uvx --generate-shell-completion zsh)"
+eval "$(ruff generate-shell-completion zsh)"
 
 # Load the shell dotfiles, and then some:
 # * ~/.extra can be used for other settings you don't want to commit.
@@ -93,15 +104,3 @@ for file in ~/.{aliases,exports,functions,extra}; do
 	[ -r "$file" ] && [ -f "$file" ] && source "$file";
 done;
 unset file;
-
-# 1Password completion and plugins
-eval "$(op completion zsh)"; compdef _op op
-source "$HOME/.config/op/plugins.sh"
-
-# Starship complettion
-eval "$(starship init zsh)"
-
-# Shell completion for uv, uvx, and ruff
-eval "$(uv generate-shell-completion zsh)"
-eval "$(uvx --generate-shell-completion zsh)"
-eval "$(ruff generate-shell-completion zsh)"


### PR DESCRIPTION
- remove unused Cursor extensions
- remove unused oh-my-zsh plugin
- typos and readme

## Summary by Sourcery

Remove the 1Password plugin and clean up scripts.

Enhancements:
- Update the README to reflect the removal of the 1Password plugin and the addition of the code.sh script.

Chores:
- Remove the unused 1Password plugin.
- Remove unnecessary newlines in print statements.
- Move sourcing of oh-my-zsh plugin before other plugins.