### PR TITLE
chore: Clean up prints

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -23,13 +23,13 @@ done
 extensions_file="${root}/linkme/.config/code/extensions.txt"
 
 export_extensions() {
-	printf "📲 \033[1;34mExporting extensions from %s to extensions.txt...\033[0m\n\n" "$2"
+	echo -e "📲 \033[1;34mExporting extensions from $2 to extensions.txt...\033[0m"
 	$1 --list-extensions >"${extensions_file}"
-	printf "✅ \033[1;32mExtensions exported to extensions.txt\033[0m\n"
+	echo -e "✅ \033[1;32mExtensions exported to extensions.txt\033[0m"
 }
 
 sync_extensions() {
-	printf "📲 \033[1;34mSyncing extensions for %s...\033[0m\n\n" "$2"
+	echo -e "📲 \033[1;34mSyncing extensions for $2...\033[0m"
 	local installed to_remove=()
 
 	# Get currently installed extensions
@@ -38,9 +38,9 @@ sync_extensions() {
 	# Install missing extensions
 	while read -r extension; do
 		if printf '%s\n' "${installed[@]}" | grep -q "^${extension}$"; then
-			printf "✅ \033[1;32mExtension '%s' already installed.\033[0m\n" "${extension}"
+			echo -e "✅ \033[1;32mExtension ${extension} already installed.\033[0m"
 		else
-			printf "⬇️  \033[1;34mInstalling extension '%s'...\033[0m\n" "${extension}"
+			echo -e "⬇️  \033[1;34mInstalling extension ${extension}...\033[0m"
 			$1 --install-extension "${extension}"
 		fi
 	done <"${extensions_file}"
@@ -54,27 +54,27 @@ sync_extensions() {
 
 	# If there are extensions to remove, ask for confirmation
 	if [[ ${#to_remove[@]} -gt 0 ]]; then
-		printf "\n❗️ \033[1;31mThe following extensions are not in extensions.txt:\033[0m\n"
+		echo -e "\n❗️ \033[1;31mThe following extensions are not in extensions.txt:\033[0m"
 		printf "  %s\n" "${to_remove[@]}"
 
 		if [[ ${auto_yes} == false ]]; then
 			read -rp $'❓ \033[1;31mDo you want to uninstall these extensions? (y/n)\033[0m ' choice
 		else
 			choice="y"
-			printf "🔄 \033[1;35mAuto-confirming removal due to -y flag\033[0m\n"
+			echo -e "🔄 \033[1;35mAuto-confirming removal due to -y flag\033[0m"
 		fi
 
 		if [[ ${choice} == "y" ]]; then
 			for extension in "${to_remove[@]}"; do
-				printf "🗑️  \033[1;35mUninstalling extension '%s'...\033[0m\n" "${extension}"
+				echo -e "🗑️  \033[1;35mUninstalling extension '${extension}'...\033[0m"
 				$1 --uninstall-extension "${extension}"
-				printf "🚮 \033[1;35mUninstalled '%s'.\033[0m\n" "${extension}"
+				echo -e "🚮 \033[1;35mUninstalled '${extension}'.\033[0m"
 			done
 		else
-			printf "🆗 \033[1;35mNo extensions were uninstalled.\033[0m\n"
+			echo -e "🆗 \033[1;35mNo extensions were uninstalled.\033[0m"
 		fi
 	else
-		printf "✅ \033[1;32mAll installed extensions are present in extensions.txt.\033[0m\n"
+		echo -e "✅ \033[1;32mAll installed extensions are present in extensions.txt.\033[0m"
 	fi
 }
 
@@ -99,8 +99,8 @@ for arg in "$@"; do
 done
 
 if [[ -z ${action} ]]; then
-	printf "\n❌ \033[1;31mError: Invalid action. Use --export or --sync\033[0m\n"
-	printf "Usage: %s [editor] [--export|--sync] [-y|--yes]\n" "$0"
+	echo -e "\n❌ \033[1;31mError: Invalid action. Use --export or --sync\033[0m"
+	echo -e "Usage: $0 [editor] [--export|--sync] [-y|--yes]"
 	exit 1
 fi
 
@@ -112,7 +112,7 @@ code-insiders) editor_name="Visual Studio Code - Insiders" ;;
 codium) editor_name="VSCodium" ;;
 cursor) editor_name="Cursor" ;;
 *)
-	printf "\n❌ \033[1;31mError: Invalid editor specified.\033[0m\n"
+	echo -e "\n❌ \033[1;31mError: Invalid editor specified.\033[0m"
 	exit 1
 	;;
 esac
@@ -123,14 +123,14 @@ if [[ "$(uname -s)" == "Darwin" ]] && [[ -d ${MACOS_BIN} ]]; then
 fi
 
 if ! type "${editor}" &>/dev/null; then
-	printf "\n❌ \033[1;31mError: %s command not on PATH.\033[0m\n" "${editor}" >&2
+	echo -e "\n❌ \033[1;31mError: ${editor} command not on PATH.\033[0m" >&2
 	exit 1
 else
 	case ${action} in
 	--export) export_extensions "${editor}" "${editor_name}" ;;
 	--sync) sync_extensions "${editor}" "${editor_name}" ;;
 	*)
-		printf "\n❌ \033[1;31mError: Invalid action\033[0m\n"
+		echo -e "\n❌ \033[1;31mError: Invalid action\033[0m"
 		exit 1
 		;;
 	esac

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ fi
 
 # Ensure yq is installed to parse the apps.toml file
 if ! command -v yq &>/dev/null; then
-	echo -e "⬇️  \033[1;34mInstalling yq to parse apps.toml...\033[0m" # needs 2 spaces after emoji
+	echo -e "⬇️ \033[1;34mInstalling yq to parse apps.toml...\033[0m"
 	brew install yq
 fi
 
@@ -99,7 +99,7 @@ install() {
 	esac
 
 	if ! ${is_installed}; then
-		echo -e "⬇️  \033[1;34mInstalling ${app_name}...\033[0m" # needs 2 spaces after emoji
+		echo -e "⬇️ \033[1;34mInstalling ${app_name}...\033[0m"
 		if ! ${cmd} "${app}"; then
 			echo -e "❌ \033[1;31mFailed to install ${app_name}. Please check manually.\033[0m"
 			return 1
@@ -136,7 +136,7 @@ brew_sync() {
 		fi
 		if [[ ${choice} == "y" ]]; then
 			for app in ${missing_apps}; do
-				echo -e "🗑️  \033[1;35mUninstalling ${app}...\033[0m" # needs 2 spaces after emoji
+				echo -e "🗑️ \033[1;35mUninstalling ${app}...\033[0m"
 				brew uninstall --zap "${app}"
 				echo -e "🚮 \033[1;35mUninstalled ${app}.\033[0m"
 			done

--- a/linkme/.gitconfig
+++ b/linkme/.gitconfig
@@ -65,7 +65,7 @@
 	ignore = "!gi() { curl -sL https://www.toptal.com/developers/gitignore/api/${@:-macos,visualstudiocode,python,pants} ;}; gi"
 	# Delete all squashed branches.
 	# https://github.com/not-an-aardvark/git-delete-squashed#sh
-	delete-squashed = "!f() { local targetBranch=${1:-main} && git checkout -q $targetBranch && git branch --merged | grep -v \"\\*\" | xargs -n 1 git branch -d && git for-each-ref refs/heads/ \"--format=%(refname:short)\" | while read branch; do mergeBase=$(git merge-base $targetBranch $branch) && [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == \"-\"* ]] && git branch -D $branch; done; }; f"
+	cleanup = "!f() { local targetBranch=${1:-main} && git checkout -q $targetBranch && git branch --merged | grep -v \"\\*\" | xargs -n 1 git branch -d && git for-each-ref refs/heads/ \"--format=%(refname:short)\" | while read branch; do mergeBase=$(git merge-base $targetBranch $branch) && [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == \"-\"* ]] && git branch -D $branch; done; }; f"
 
 [pager]
 	stash = false

--- a/linkme/.zshrc
+++ b/linkme/.zshrc
@@ -6,7 +6,7 @@ export ZSH="$HOME/.oh-my-zsh"
 
 # Install oh-my-zsh if it isn't installed yet
 if [ ! -f "$ZSH/oh-my-zsh.sh" ]; then
-	echo -e "⬇️  \033[1;34mInstalling oh-my-zsh...\033[0m" # needs 2 spaces after emoji
+	echo -e "⬇️ \033[1;34mInstalling oh-my-zsh...\033[0m"
 	if [ -d "$ZSH" ]; then
 		echo -e "❗️ \033[1;31mMoving ${ZSH} to ${ZSH}.bak, please sync dotfiles after finishing.\033[0m"
 		cp -r $ZSH $ZSH.bak


### PR DESCRIPTION
- don't use double spaces for emoji because it's only an issue in Terminal.app/VSCode
- also rename git alias from 'delete-squashed' to 'cleanup'

## Summary by Sourcery

Chores:
- Remove extra spaces after emojis in print statements.