### PR TITLE
chore: Add extensions to Cursor

### DIFF
--- a/linkme/.config/code/extensions.txt
+++ b/linkme/.config/code/extensions.txt
@@ -1,3 +1,4 @@
+anysphere.pyright
 batisteo.vscode-django
 bierner.emojisense
 bierner.markdown-mermaid
@@ -52,6 +53,7 @@ ms-vscode.remote-repositories
 ms-vscode.vscode-github-issue-notebooks
 ms-vsliveshare.vsliveshare
 mtxr.sqltools
+mtxr.sqltools-driver-mysql
 mushan.vscode-paste-image
 naumovs.color-highlight
 nhoizey.gremlins


### PR DESCRIPTION
- pyright (built-in) and mysql driver for sqltools

## Summary by Sourcery

Chores:
- Add pyright and mysql driver extensions to the list of extensions.