### PR TITLE
feat: replace Google Chrome with chrome command

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -67,7 +67,6 @@ arc = "cask" # Chromium based browser
 calibre = "cask" # E-books management software
 dropbox = "cask" # Client for the Dropbox cloud storage service
 expressvpn = "cask" # VPN client for secure internet access and private browsing
-google-chrome = "cask" # Web browser
 google-drive = "cask" # Client for the Google Drive storage service
 iina = "cask" # Free and open-source media player [modern vlc alternative]
 istat-menus = "cask" # System monitoring app

--- a/linkme/.functions
+++ b/linkme/.functions
@@ -14,6 +14,10 @@ function bootstrap() {
 	bash "${DOTPATH}/bootstrap.sh" -y
 }
 
+function chrome() {
+	uvx --with "selenium" python -c "from selenium import webdriver; driver = webdriver.Chrome(); input('Press Enter to exit...')"
+}
+
 # Start screensaver.
 function ss() {
 	open -a ScreenSaverEngine


### PR DESCRIPTION
- use uv, selenium, and chromedriver to launch an instance of Chrome using the 'chrome' command

## Summary by Sourcery

Chores:
- Removes the google-chrome cask.