### PR TITLE
chore: sync cursor settings

### DIFF
--- a/linkme/.config/marimo/marimo.toml
+++ b/linkme/.config/marimo/marimo.toml
@@ -1,37 +1,57 @@
-[display]
-theme = "light"
-default_width = "medium"
-dataframes = "rich"
-code_editor_font_size = 14
-cell_output = "above"
+[server]
+browser = "default"
+follow_symlink = false
+
+[experimental]
+
+[ai]
+rules = ""
 
 [keymap]
 preset = "default"
 
 [keymap.overrides]
 
-[save]
-autosave = "after_delay"
-format_on_save = true
-autosave_delay = 1000
-
-[server]
-follow_symlink = false
-browser = "default"
-
-[package_management]
-manager = "uv"
+[completion]
+activate_on_typing = true
+copilot = "github"
 
 [formatting]
 line_length = 99
 
-[experimental]
-
 [runtime]
-auto_reload = "off"
-on_cell_change = "autorun"
+pythonpath = []
+watcher_on_save = "lazy"
+std_stream_max_bytes = 1000000
+output_max_bytes = 8000000
 auto_instantiate = true
+auto_reload = "off"
+on_cell_change = "lazy"
 
-[completion]
-activate_on_typing = true
-copilot = "github"
+[save]
+autosave_delay = 1000
+autosave = "off"
+format_on_save = true
+
+[package_management]
+manager = "uv"
+
+[display]
+default_width = "medium"
+theme = "light"
+dataframes = "rich"
+cell_output = "above"
+code_editor_font_size = 14
+
+[language_servers.pylsp]
+enable_pylint = false
+enable_ruff = true
+enabled = true
+enable_flake8 = false
+enable_pyflakes = false
+enable_mypy = true
+enable_pydocstyle = false
+
+[snippets]
+include_default_snippets = true
+custom_paths = []

--- a/linkme/Library/Application Support/Cursor/User/keybindings.json
+++ b/linkme/Library/Application Support/Cursor/User/keybindings.json
@@ -1,12 +1,12 @@
 // Place your key bindings in this file to override the defaults
 [
   // {
-  //     "key": "ctrl+tab",
-  //     "command": "workbench.action.nextEditor"
+  //     "command": "workbench.action.nextEditor",
+  //     "key": "ctrl+tab"
   // },
   // {
-  //     "key": "ctrl+shift+tab",
-  //     "command": "workbench.action.previousEditor"
+  //     "command": "workbench.action.previousEditor",
+  //     "key": "ctrl+shift+tab"
   // },
   {
     "command": "workbench.action.terminal.clear",
@@ -43,23 +43,43 @@
     "key": "shift+cmd+l"
   },
   {
-    "key": "ctrl+cmd+p",
     "command": "workbench.action.unpinEditor",
-    "when": "activeEditorIsPinned"
-  },
-  {
-    "key": "cmd+r shift+enter",
-    "command": "-workbench.action.unpinEditor",
-    "when": "activeEditorIsPinned"
-  },
-  {
     "key": "ctrl+cmd+p",
+    "when": "activeEditorIsPinned"
+  },
+  {
+    "command": "-workbench.action.unpinEditor",
+    "key": "cmd+r shift+enter",
+    "when": "activeEditorIsPinned"
+  },
+  {
     "command": "workbench.action.pinEditor",
+    "key": "ctrl+cmd+p",
     "when": "!activeEditorIsPinned"
   },
   {
-    "key": "cmd+r shift+enter",
     "command": "-workbench.action.pinEditor",
+    "key": "cmd+r shift+enter",
     "when": "!activeEditorIsPinned"
+  },
+  {
+    "command": "jupyter.runcurrentcell",
+    "key": "cmd+enter",
+    "when": "editorTextFocus && isWorkspaceTrusted && jupyter.hascodecells && !editorHasSelection && !isCompositeNotebook && !notebookEditorFocused"
+  },
+  {
+    "command": "-jupyter.runcurrentcell",
+    "key": "ctrl+enter",
+    "when": "editorTextFocus && isWorkspaceTrusted && jupyter.hascodecells && !editorHasSelection && !isCompositeNotebook && !notebookEditorFocused"
+  },
+  {
+    "command": "notebook.cell.executeAndSelectBelow",
+    "key": "cmd+enter",
+    "when": "notebookCellListFocused && !interactiveEditorFocused && notebookCellType == 'code' || editorTextFocus && inputFocus && notebookEditorFocused && !interactiveEditorFocused"
+  },
+  {
+    "command": "-notebook.cell.executeAndSelectBelow",
+    "key": "shift+enter",
+    "when": "notebookCellListFocused && !interactiveEditorFocused && notebookCellType == 'code' || editorTextFocus && inputFocus && notebookEditorFocused && !interactiveEditorFocused"
   }
 ]

--- a/linkme/Library/Application Support/Cursor/User/settings.json
+++ b/linkme/Library/Application Support/Cursor/User/settings.json
@@ -80,7 +80,6 @@
   "editor.largeFileOptimizations": false,
   "editor.minimap.maxColumn": 100,
   "editor.minimap.showSlider": "always",
-  "editor.multiCursorModifier": "ctrlCmd",
   "editor.renderWhitespace": "all",
   "editor.rulers": [99, 119],
   "editor.snippetSuggestions": "top",


### PR DESCRIPTION
- update keybindings (cmd+enter to run jupyter cells)
- change multicursor to alt+click (links in terminal now open with cmd+click instead, see: https://stackoverflow.com/a/77269266/4760185)
- add marimo update

## Summary by Sourcery

Update Cursor and Marimo configuration settings to improve development workflow and user experience

Enhancements:
- Modify Marimo runtime and language server configurations
- Update Cursor IDE settings to improve multi-cursor and keybinding behaviors

Chores:
- Synchronize and optimize configuration settings for Marimo and Cursor IDE