### PR TITLE
chore: update sqltools settings

### DIFF
--- a/linkme/Library/Application Support/Cursor/User/keybindings.json
+++ b/linkme/Library/Application Support/Cursor/User/keybindings.json
@@ -88,6 +88,7 @@
   },
   {
     "command": "sqltools.executeCurrentQuery",
-    "key": "cmd+enter"
+    "key": "cmd+enter",
+    "when": "editorTextFocus && editorLangId == 'sql' && !config.sqltools.disableChordKeybindings"
   }
 ]

--- a/linkme/Library/Application Support/Cursor/User/settings.json
+++ b/linkme/Library/Application Support/Cursor/User/settings.json
@@ -146,6 +146,7 @@
   "redhat.telemetry.enabled": true,
   "rewrap.wrappingColumn": 79,
   "snowflake.connectionsConfigFile": "~/.snowflake/connections.toml",
+  "sqltools.results.reuseTabs": "connection",
   "terminal.integrated.defaultProfile.osx": "zsh",
   "terminal.integrated.env.osx": {
     "FIG_NEW_SESSION": "1"


### PR DESCRIPTION
- don't open new tab for every query
- fix keybinding

## Summary by Sourcery

Chores:
- Modify Cursor editor settings to optimize SQLTools extension behavior