### PR TITLE
fix: print parsing

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -73,7 +73,10 @@ if [[ ${COPYME} =~ ^[Yy]$ ]]; then
 	echo -e "📝 \033[1;35mCopying files from copyme/ to ${HOME}...\033[0m"
 	rsync -av --exclude='.DS_Store' copyme/ "${HOME}" |
 		grep -v "building file list ... done" |
-		awk '/^$/ { exit } !/\/$/ { printf "✅ \033[1;32mCopied copyme/%s -> ~/%s\033[0m\n", $0, $0; }'
+		grep -v "Transfer starting:" |
+		grep -v "sent " |
+		grep -v "total size" |
+		awk '/^[^.]/{next} /^\.\/$/{next} /^$/ { exit } { sub(/\/$/, "", $0); printf "✅ \033[1;32mCopied copyme/%s -> ~/%s\033[0m\n", $0, $0; }'
 	# 1Password needs the permissions to be set to 700
 	chmod 700 "${HOME}/.config/op"
 	chmod 700 "${HOME}/.config/op/plugins/used_items"


### PR DESCRIPTION
- fix misparsed rysnc output to print to console

## Summary by Sourcery

Refine rsync output parsing to correctly print copied files and suppress extraneous lines

Bug Fixes:
- Improve filtering pipeline to exclude summary, transfer, and total size lines
- Adjust awk logic to accurately format and terminate file copy confirmations