### PR TITLE
chore: update apps

### DIFF
--- a/apps.toml
+++ b/apps.toml
@@ -21,6 +21,7 @@ shellcheck = "formula" # Static analysis and lint tool, for (ba)sh scripts
 shfmt = "formula" # Autoformat shell script source code
 sqlfluff = "uv" # SQL linter and auto-formatter for Humans
 trunk-io = "cask" # Developer experience toolkit used to check, test, merge, and monitor code
+windsurf = "cask" # Agentic IDE powered by AI Flow paradigm
 yamllint = "uv" # Linter for YAML files
 
 [work]
@@ -47,7 +48,6 @@ spotify = "cask" # Music streaming service
 # 1048524688 = "mas" # Delta - Game Emulator: All-in-One GBA4iOS Successor [not working, see: https://github.com/mas-cli/mas/issues/321]
 
 [productivity]
-claude = "cask" # Anthropic's official Claude AI desktop app
 linear-linear = "cask" # App to manage software development and track bugs
 notion = "cask" # App to write, plan, collaborate, and get organised
 obsidian = "cask" # Knowledge base that works on top of a local folder of plain text Markdown files


### PR DESCRIPTION
- install windsurf
- uninstall claude

## Summary by Sourcery

Update apps.toml to install the new windsurf tool and uninstall the Claude app

New Features:
- Add windsurf cask entry to apps.toml for the agentic IDE

Chores:
- Remove claude cask entry from apps.toml