### PR TITLE
fix: uninstall ambiguous brew package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,9 +135,14 @@ brew_sync() {
 			choice="y"
 		fi
 		if [[ ${choice} == "y" ]]; then
-			for app in ${missing_apps}; do
+			for app in ${missing_formulae}; do
 				echo -e "🗑️ \033[1;35mUninstalling ${app}...\033[0m"
 				brew uninstall --zap "${app}"
+				echo -e "🚮 \033[1;35mUninstalled ${app}.\033[0m"
+			done
+			for app in ${missing_casks}; do
+				echo -e "🗑️ \033[1;35mUninstalling ${app}...\033[0m"
+				brew uninstall --cask --zap "${app}"
 				echo -e "🚮 \033[1;35mUninstalled ${app}.\033[0m"
 			done
 		else


### PR DESCRIPTION
- ensure --cask flag is passed when uninstalling homebrew casks to avoid possible name clashes between formulas and casks

## Summary by Sourcery

Refine the brew_sync uninstall logic to separately handle formulae and casks and use the --cask flag when removing casks to prevent name clashes.

Bug Fixes:
- Ensure brew uninstall uses the --cask flag for casks to avoid ambiguous removals between formulas and casks.

Enhancements:
- Split the uninstall loop into two: one for missing formulae and one for missing casks.