### PR TITLE
chore: remove slack from dock

### DIFF
--- a/dock.sh
+++ b/dock.sh
@@ -158,7 +158,6 @@ clear_dock
 add_app_to_dock "Arc"
 add_app_to_dock "Obsidian"
 add_app_to_dock "Todoist"
-add_app_to_dock "Slack"
 add_app_to_dock "Cursor"
 add_app_to_dock "Ghostty"
 add_app_to_dock "System Settings"


### PR DESCRIPTION
- less distraction

## Summary by Sourcery

Chores:
- Remove the Slack entry from the dock setup in dock.sh