### PR TITLE
chore: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -1,7 +1,7 @@
 ---
 name: Validate Pull Request
 on: # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
- pull_request is safer
- see: https://runs-on.com/github-actions/pull-request-vs-pull-request-target/#best-practices
- see: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/