### PR TITLE
chore: enable Cursor Tab on markdown files

### DIFF
--- a/linkme/.config/code/extensions.txt
+++ b/linkme/.config/code/extensions.txt
@@ -1,5 +1,4 @@
 anysphere.cursorpyright
-anysphere.pyright
 batisteo.vscode-django
 bierner.emojisense
 bierner.markdown-mermaid
@@ -41,7 +40,6 @@ ms-azuretools.vscode-docker
 ms-python.debugpy
 ms-python.isort
 ms-python.python
-ms-python.vscode-pylance
 ms-toolsai.jupyter
 ms-toolsai.jupyter-keymap
 ms-toolsai.jupyter-renderers

--- a/linkme/Library/Application Support/Cursor/User/settings.json
+++ b/linkme/Library/Application Support/Cursor/User/settings.json
@@ -70,6 +70,7 @@
     "unparsable",
     "untrusted"
   ],
+  "cursor.cpp.disabledLanguages": ["plaintext"],
   "editor.acceptSuggestionOnEnter": "on",
   "editor.accessibilitySupport": "off",
   "editor.cursorBlinking": "phase",


### PR DESCRIPTION
- update extensions as well