### PR TITLE
chore: intray cache

### DIFF
--- a/linkme/.config/mole/whitelist
+++ b/linkme/.config/mole/whitelist
@@ -16,6 +16,7 @@
 ~/Library/Caches/com.apple.Spotlight*
 ~/Library/Caches/com.jetbrains.toolbox*
 ~/Library/Caches/com.nssurge.surge-mac/*
+~/Library/Caches/intray/*
 ~/Library/Caches/JetBrains*
 ~/Library/Caches/ms-playwright*
 ~/Library/Caches/tealdeer/tldr-pages


### PR DESCRIPTION
- don't clean intray cache by default