### PR TITLE
fix: get correct python version from uv in starship

### DIFF
--- a/linkme/.config/starship.toml
+++ b/linkme/.config/starship.toml
@@ -21,7 +21,8 @@ symbol = "☕️"
 
 [python]
 python_binary = [
-  ["uv", "run", "--no-python-downloads", "--no-project", "python"]
+  ["uv", "run", "--no-python-downloads", "--no-project", "python"],
+  "python",
 ]
 
 [username]

--- a/linkme/.config/starship.toml
+++ b/linkme/.config/starship.toml
@@ -1,6 +1,6 @@
-# Get editor completions based on the config schema
-"$schema" = "https://starship.rs/config-schema.json"
-# Inserts a blank line between shell prompts
+#:schema https://raw.githubusercontent.com/martimlobao/starship/refs/heads/chore/python-binary-schema-context/.github/config-schema.json
+# Change back to `https://starship.rs/config-schema.json` after merging https://github.com/starship/starship/pull/7415
+
 add_newline = true
 
 [battery]
@@ -18,6 +18,11 @@ symbol = "🌱 "
 
 [nodejs]
 symbol = "☕️"
+
+[python]
+python_binary = [
+  ["uv", "run", "--no-python-downloads", "--no-project", "python"]
+]
 
 [username]
 style_user = "bold dimmed blue"


### PR DESCRIPTION
- modify python_binary to use uv version
- fix schema (see: https://github.com/starship/starship/pull/7415)
- load schema correctly for tombi (use `#:schema`)