### PR TITLE
chore(config): restore starship schema url

### DIFF
--- a/linkme/.config/starship.toml
+++ b/linkme/.config/starship.toml
@@ -1,5 +1,4 @@
-#:schema https://raw.githubusercontent.com/martimlobao/starship/refs/heads/chore/python-binary-schema-context/.github/config-schema.json
-# Change back to `https://starship.rs/config-schema.json` after merging https://github.com/starship/starship/pull/7415
+#:schema https://starship.rs/config-schema.json
 
 add_newline = true
 


### PR DESCRIPTION
- use the upstream starship config schema url
- remove the temporary schema override comment
- bad schema now fixed via https://github.com/starship/starship/pull/7415