### PR TITLE
fix(apps): trust Homebrew taps before install

### DIFF
--- a/scripts/app.py
+++ b/scripts/app.py
@@ -716,15 +716,15 @@ class BaseSourceService(ABC):
         del app, auto_yes
 
     def ensure_installed(self, app: str, *, auto_yes: bool = False) -> OperationResult:
-        preflight: OperationResult | None = self.pre_install_check(app)
-        if preflight is not None:
-            return preflight
-
         self.prepare_install(app, auto_yes=auto_yes)
         if self.is_installed(app):
             return OperationResult.skipped_result(
                 f"{app!r} is already installed via {self.source_name}."
             )
+
+        preflight: OperationResult | None = self.pre_install_check(app)
+        if preflight is not None:
+            return preflight
 
         self.console.paint(f"Installing {app!r} via {self.source_name}...", Ansi.BLUE, icon="⬇️")
         self.install(app)

--- a/scripts/app.py
+++ b/scripts/app.py
@@ -52,6 +52,7 @@ type JSON = dict[str, JSON] | list[JSON] | str | int | float | bool | None
 
 DOTPATH: Path = Path(os.environ.get("DOTPATH", Path(__file__).resolve().parent.parent))
 APPS_TOML: Path = DOTPATH / "apps.toml"
+FULLY_QUALIFIED_HOMEBREW_APP_SLASHES = 2
 
 
 class AppManagerError(Exception):
@@ -710,15 +711,20 @@ class BaseSourceService(ABC):
         }
         return bool(aliases & installed_tokens)
 
-    def ensure_installed(self, app: str) -> OperationResult:
+    def prepare_install(self, app: str, *, auto_yes: bool) -> None:
+        _ = self
+        del app, auto_yes
+
+    def ensure_installed(self, app: str, *, auto_yes: bool = False) -> OperationResult:
+        preflight: OperationResult | None = self.pre_install_check(app)
+        if preflight is not None:
+            return preflight
+
+        self.prepare_install(app, auto_yes=auto_yes)
         if self.is_installed(app):
             return OperationResult.skipped_result(
                 f"{app!r} is already installed via {self.source_name}."
             )
-
-        preflight: OperationResult | None = self.pre_install_check(app)
-        if preflight is not None:
-            return preflight
 
         self.console.paint(f"Installing {app!r} via {self.source_name}...", Ansi.BLUE, icon="⬇️")
         self.install(app)
@@ -789,6 +795,52 @@ class BrewSourceService(BaseSourceService, ABC):
         brew: str = self._brew()
         result = self.runner.run([brew, "list", self.list_flag])
         return {item: item for item in result.stdout.split()}
+
+    def prepare_install(self, app: str, *, auto_yes: bool) -> None:
+        tap: str | None = self._third_party_tap(app)
+        if tap is None or self._tap_is_trusted(tap):
+            return
+
+        if auto_yes or self.console.prompt_yes_no(
+            f"Trust Homebrew tap {tap}? (y/n) ",
+            auto_yes=False,
+        ):
+            brew: str = self._brew()
+            self.runner.run([brew, "trust", "--tap", tap])
+
+    @staticmethod
+    def _third_party_tap(app: str) -> str | None:
+        if app.count("/") != FULLY_QUALIFIED_HOMEBREW_APP_SLASHES:
+            return None
+
+        owner, tap_name, _ = app.split("/", 2)
+        tap = f"{owner}/{tap_name}"
+        if owner.casefold() == "homebrew":
+            return None
+        return tap
+
+    def _tap_is_trusted(self, tap: str) -> bool:
+        trust_file = self._trust_file()
+        try:
+            store = json.loads(trust_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+
+        if not isinstance(store, dict):
+            return False
+
+        trusted_taps = store.get("trustedtaps", [])
+        if not isinstance(trusted_taps, list):
+            return False
+
+        return tap.casefold() in {str(trusted_tap).casefold() for trusted_tap in trusted_taps}
+
+    @staticmethod
+    def _trust_file() -> Path:
+        config_home = os.environ.get("HOMEBREW_USER_CONFIG_HOME")
+        if config_home:
+            return Path(config_home) / "trust.json"
+        return Path.home() / ".homebrew" / "trust.json"
 
     def install(self, app: str) -> None:
         brew: str = self._brew()
@@ -1185,6 +1237,7 @@ class AppManagerFacade:
         group: str | None,
         description: str | None,
         no_install: bool,
+        yes: bool = False,
     ) -> None:
         document = self.repository.load()
         selected_group: str = self._resolve_or_pick_group(document, group)
@@ -1246,7 +1299,8 @@ class AppManagerFacade:
         if not failure_message:
             try:
                 install_result: OperationResult = self.get_service(source).ensure_installed(
-                    outcome.app_key
+                    outcome.app_key,
+                    auto_yes=yes,
                 )
             except AppManagerError as error:
                 failure_message = str(error)
@@ -1476,7 +1530,8 @@ class AppManagerFacade:
                     current_group = group
 
                 result: OperationResult = self.get_service(record.source).ensure_installed(
-                    record.key
+                    record.key,
+                    auto_yes=options.yes,
                 )
                 if result.skipped and "Skipping" in result.message:
                     self.console.paint(result.message, Ansi.RED, icon="⏭️")
@@ -1595,6 +1650,7 @@ class AddAppCommand(BaseCommand):
             group=args.group,
             description=args.description,
             no_install=args.no_install,
+            yes=args.yes,
         )
 
 
@@ -1700,6 +1756,12 @@ def parse_args() -> argparse.Namespace:
         "--no-install",
         action="store_true",
         help="Skip installing or uninstalling apps and only update the apps.toml file",
+    )
+    add_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Auto-confirm Homebrew tap trust prompts",
     )
 
     remove_parser = subparsers.add_parser(

--- a/scripts/tests/test_app.py
+++ b/scripts/tests/test_app.py
@@ -479,6 +479,20 @@ def test_base_strategy_ensure_installed_skips_when_installed() -> None:
     assert result.skipped
 
 
+def test_base_strategy_ensure_installed_skips_preflight_when_installed() -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    service = app_module.BrewFormulaSourceService(runner=runner, console=app_module.Console())
+    with (
+        patch.object(service, "prepare_install") as prepare,
+        patch.object(service, "is_installed", return_value=True),
+        patch.object(service, "pre_install_check") as preflight,
+    ):
+        result = service.ensure_installed("owner/tap/tool")
+    assert result.skipped
+    prepare.assert_called_once_with("owner/tap/tool", auto_yes=False)
+    preflight.assert_not_called()
+
+
 def test_base_strategy_ensure_uninstalled_skips_when_not_installed() -> None:
     runner = Mock(spec=app_module.CommandRunner)
     service = app_module.UvSourceService(runner=runner, console=app_module.Console())

--- a/scripts/tests/test_app.py
+++ b/scripts/tests/test_app.py
@@ -1363,6 +1363,7 @@ def test_brew_ensure_installed_skips_tap_trust_for_short_name() -> None:
     service = app_module.BrewFormulaSourceService(runner=runner, console=console)
 
     with (
+        patch("app_module.platform.system", return_value="Darwin"),
         patch.object(service, "is_installed", return_value=False),
         patch.object(console, "prompt_yes_no") as prompt,
     ):
@@ -1380,6 +1381,7 @@ def test_brew_ensure_installed_skips_tap_trust_for_official_tap() -> None:
     service = app_module.BrewFormulaSourceService(runner=runner, console=console)
 
     with (
+        patch("app_module.platform.system", return_value="Darwin"),
         patch.object(service, "is_installed", return_value=False),
         patch.object(console, "prompt_yes_no") as prompt,
     ):
@@ -1418,6 +1420,7 @@ def test_brew_ensure_installed_skips_prompt_for_already_trusted_tap(tmp_path: Pa
     service = app_module.BrewFormulaSourceService(runner=runner, console=console)
 
     with (
+        patch("app_module.platform.system", return_value="Darwin"),
         patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
         patch.object(service, "is_installed", return_value=False),
         patch.object(console, "prompt_yes_no") as prompt,
@@ -1436,6 +1439,7 @@ def test_brew_ensure_installed_trusts_tap_when_prompt_accepted(tmp_path: Path) -
     service = app_module.BrewFormulaSourceService(runner=runner, console=console)
 
     with (
+        patch("app_module.platform.system", return_value="Darwin"),
         patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
         patch.object(service, "is_installed", return_value=False),
         patch.object(console, "prompt_yes_no", return_value=True) as prompt,
@@ -1457,6 +1461,7 @@ def test_brew_ensure_installed_does_not_trust_tap_when_prompt_declined(tmp_path:
     service = app_module.BrewFormulaSourceService(runner=runner, console=console)
 
     with (
+        patch("app_module.platform.system", return_value="Darwin"),
         patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
         patch.object(service, "is_installed", return_value=False),
         patch.object(console, "prompt_yes_no", return_value=False) as prompt,

--- a/scripts/tests/test_app.py
+++ b/scripts/tests/test_app.py
@@ -80,6 +80,14 @@ def test_parse_args_add_command() -> None:
     assert args.group == "cli"
 
 
+def test_parse_args_add_yes_flag() -> None:
+    argv = ["app", "add", "owner/tap/tool", "formula", "--group", "cli", "-y"]
+    with patch.object(sys, "argv", argv):
+        args = app_module.parse_args()
+    assert args.command == "add"
+    assert args.yes
+
+
 def test_parse_args_sync_flags() -> None:
     argv = ["app", "sync", "--no-cask", "--no-formula"]
     with patch.object(sys, "argv", argv):
@@ -562,6 +570,7 @@ def test_facade_add_app_no_install(tmp_path: Path) -> None:
         group="tools",
         description="desc",
         no_install=True,
+        yes=False,
     )
     text = apps_file.read_text()
     assert "[tools]" in text
@@ -585,10 +594,11 @@ def test_facade_add_app_source_change_calls_uninstall_and_install(tmp_path: Path
             group="cli",
             description="desc",
             no_install=False,
+            yes=True,
         )
 
     previous_source_service.ensure_uninstalled.assert_called_once_with("httpie")
-    new_source_service.ensure_installed.assert_called_once_with("httpie")
+    new_source_service.ensure_installed.assert_called_once_with("httpie", auto_yes=True)
 
 
 def test_facade_add_app_rolls_back_when_install_fails(tmp_path: Path) -> None:
@@ -607,6 +617,7 @@ def test_facade_add_app_rolls_back_when_install_fails(tmp_path: Path) -> None:
             group="cli",
             description="desc",
             no_install=False,
+            yes=False,
         )
 
     assert apps_file.read_text() == initial_text
@@ -634,6 +645,7 @@ def test_facade_add_app_rolls_back_when_uninstall_fails(tmp_path: Path) -> None:
             group="cli",
             description="desc",
             no_install=False,
+            yes=False,
         )
 
     assert apps_file.read_text() == initial_text
@@ -729,8 +741,21 @@ def test_facade_install_declared_skips_disabled_source(tmp_path: Path) -> None:
     with patch.object(facade, "get_service", side_effect=service_for):
         facade._install_declared(grouped, options)
 
-    uv_service.ensure_installed.assert_called_once_with("httpie")
+    uv_service.ensure_installed.assert_called_once_with("httpie", auto_yes=False)
     cask_service.ensure_installed.assert_not_called()
+
+
+def test_facade_install_declared_passes_auto_yes(tmp_path: Path) -> None:
+    facade, _, _ = build_facade(tmp_path)
+    formula_service = Mock()
+    formula_service.ensure_installed.return_value = app_module.OperationResult.ok("ok")
+    grouped = [("cli", [app_module.AppRecord("cli", "owner/tap/tool", "formula", "")])]
+    options = app_module.SyncOptions(yes=True, enabled_sources={"formula"})
+
+    with patch.object(facade, "get_service", return_value=formula_service):
+        facade._install_declared(grouped, options)
+
+    formula_service.ensure_installed.assert_called_once_with("owner/tap/tool", auto_yes=True)
 
 
 def test_facade_sync_unmanaged_no_missing(
@@ -876,9 +901,17 @@ def test_add_command_executes_facade(tmp_path: Path) -> None:
                 group="cli",
                 description="desc",
                 no_install=True,
+                yes=True,
             )
         )
-        add.assert_called_once()
+        add.assert_called_once_with(
+            app="foo",
+            source="uv",
+            group="cli",
+            description="desc",
+            no_install=True,
+            yes=True,
+        )
 
 
 def test_remove_command_executes_facade(tmp_path: Path) -> None:
@@ -1283,6 +1316,139 @@ def test_brew_source_methods_install_uninstall_upgrade_and_aliases() -> None:
     assert runner.run.call_count >= 5
 
 
+def test_brew_ensure_installed_skips_tap_trust_for_short_name() -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no") as prompt,
+    ):
+        service.ensure_installed("gh")
+
+    prompt.assert_not_called()
+    runner.run.assert_called_once_with(["brew", "install", "--formula", "gh"])
+
+
+def test_brew_ensure_installed_skips_tap_trust_for_official_tap() -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no") as prompt,
+    ):
+        service.ensure_installed("homebrew/core/gh")
+
+    prompt.assert_not_called()
+    runner.run.assert_called_once_with(["brew", "install", "--formula", "homebrew/core/gh"])
+
+
+def test_brew_ensure_installed_trusts_tap_even_when_already_installed(tmp_path: Path) -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
+        patch.object(service, "is_installed", return_value=True),
+        patch.object(console, "prompt_yes_no", return_value=True) as prompt,
+    ):
+        result = service.ensure_installed("owner/tap/tool")
+
+    prompt.assert_called_once_with("Trust Homebrew tap owner/tap? (y/n) ", auto_yes=False)
+    assert result.skipped
+    runner.run.assert_called_once_with(["brew", "trust", "--tap", "owner/tap"])
+
+
+def test_brew_ensure_installed_skips_prompt_for_already_trusted_tap(tmp_path: Path) -> None:
+    trust_file = tmp_path / "trust.json"
+    trust_file.write_text(json.dumps({"trustedtaps": ["owner/tap"]}))
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no") as prompt,
+    ):
+        service.ensure_installed("owner/tap/tool")
+
+    prompt.assert_not_called()
+    runner.run.assert_called_once_with(["brew", "install", "--formula", "owner/tap/tool"])
+
+
+def test_brew_ensure_installed_trusts_tap_when_prompt_accepted(tmp_path: Path) -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no", return_value=True) as prompt,
+    ):
+        service.ensure_installed("owner/tap/tool")
+
+    prompt.assert_called_once_with("Trust Homebrew tap owner/tap? (y/n) ", auto_yes=False)
+    assert runner.run.call_args_list == [
+        ((["brew", "trust", "--tap", "owner/tap"],), {}),
+        ((["brew", "install", "--formula", "owner/tap/tool"],), {}),
+    ]
+
+
+def test_brew_ensure_installed_does_not_trust_tap_when_prompt_declined(tmp_path: Path) -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=console)
+
+    with (
+        patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no", return_value=False) as prompt,
+    ):
+        service.ensure_installed("owner/tap/tool")
+
+    prompt.assert_called_once_with("Trust Homebrew tap owner/tap? (y/n) ", auto_yes=False)
+    runner.run.assert_called_once_with(["brew", "install", "--formula", "owner/tap/tool"])
+
+
+def test_brew_ensure_installed_auto_trusts_tap_without_prompt(tmp_path: Path) -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    console = app_module.Console()
+    service = app_module.BrewCaskSourceService(runner=runner, console=console)
+
+    with (
+        patch.dict(app_module.os.environ, {"HOMEBREW_USER_CONFIG_HOME": str(tmp_path)}),
+        patch.object(service, "is_installed", return_value=False),
+        patch.object(console, "prompt_yes_no") as prompt,
+    ):
+        service.ensure_installed("owner/tap/tool", auto_yes=True)
+
+    prompt.assert_not_called()
+    assert runner.run.call_args_list == [
+        ((["brew", "trust", "--tap", "owner/tap"],), {}),
+        ((["brew", "install", "--cask", "owner/tap/tool"],), {}),
+    ]
+
+
 def test_brew_extract_install_state_with_list() -> None:
     installed, version = app_module.BrewSourceService._extract_install_state({
         "installed": [{"version": "1.2.3"}]
@@ -1555,6 +1721,7 @@ def test_facade_add_app_fails_when_uninstall_returns_failure_status(tmp_path: Pa
             group="cli",
             description="desc",
             no_install=False,
+            yes=False,
         )
 
     assert apps_file.read_text() == initial_text
@@ -1577,6 +1744,7 @@ def test_facade_add_app_fails_when_install_returns_failure_status(tmp_path: Path
             group="cli",
             description="desc",
             no_install=False,
+            yes=False,
         )
 
     assert apps_file.read_text() == initial_text

--- a/scripts/tests/test_app.py
+++ b/scripts/tests/test_app.py
@@ -99,6 +99,14 @@ def test_parse_args_sync_flags() -> None:
     assert args.install_mas
 
 
+def test_parse_args_sync_yes_flag() -> None:
+    argv = ["app", "sync", "-y"]
+    with patch.object(sys, "argv", argv):
+        args = app_module.parse_args()
+    assert args.command == "sync"
+    assert args.yes
+
+
 def test_command_runner_get_executable_raises() -> None:
     runner = app_module.CommandRunner()
     with (
@@ -967,7 +975,24 @@ def test_sync_command_builds_options_and_executes_facade(tmp_path: Path) -> None
         cmd.execute(args)
         sync.assert_called_once()
         options = sync.call_args[0][0]
+        assert options.yes
         assert options.enabled_sources == {"formula", "uv"}
+
+
+def test_main_sync_command_propagates_yes_flag(tmp_path: Path) -> None:
+    apps_file = tmp_path / "apps.toml"
+    apps_file.write_text("")
+    argv = ["app", "--apps-file", str(apps_file), "sync", "-y"]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch.object(app_module.AppManagerFacade, "sync_apps") as sync,
+    ):
+        app_module.main()
+
+    sync.assert_called_once()
+    options = sync.call_args[0][0]
+    assert options.yes
 
 
 def test_main_list_command(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
- prompt for untrusted fully qualified Homebrew taps before install checks
- auto-trust taps from `app add -y` and `app sync -y`
- context: https://github.com/Homebrew/brew/pull/22470 and https://github.com/Homebrew/brew/pull/22472