### PR TITLE
fix: auto-accept Homebrew upgrades

### DIFF
--- a/scripts/app.py
+++ b/scripts/app.py
@@ -854,7 +854,7 @@ class BrewSourceService(BaseSourceService, ABC):
     def upgrade_all(self) -> None:
         brew: str = self._brew()
         self.runner.run([brew, "update"], capture_output=False)
-        self.runner.run([brew, "upgrade"], capture_output=False)
+        self.runner.run([brew, "upgrade", "--yes"], capture_output=False)
         self.runner.run([brew, "cleanup"], capture_output=False)
 
     def fetch_info(

--- a/scripts/tests/test_app.py
+++ b/scripts/tests/test_app.py
@@ -1355,6 +1355,17 @@ def test_brew_source_methods_install_uninstall_upgrade_and_aliases() -> None:
     assert runner.run.call_count >= 5
 
 
+def test_brew_upgrade_all_auto_accepts_upgrade_prompt() -> None:
+    runner = Mock(spec=app_module.CommandRunner)
+    runner.get_executable.return_value = "brew"
+    runner.run.return_value = make_result()
+    service = app_module.BrewFormulaSourceService(runner=runner, console=app_module.Console())
+
+    service.upgrade_all()
+
+    runner.run.assert_any_call(["brew", "upgrade", "--yes"], capture_output=False)
+
+
 def test_brew_ensure_installed_skips_tap_trust_for_short_name() -> None:
     runner = Mock(spec=app_module.CommandRunner)
     runner.get_executable.return_value = "brew"


### PR DESCRIPTION
- pass --yes to brew upgrade during app sync
- add regression coverage for the Homebrew upgrade command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew "upgrade all" command now automatically accepts upgrade prompts without requiring manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->